### PR TITLE
Update utils.py

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -397,6 +397,7 @@ def get_beneficiaries(request_header):
         print(beneficiaries.status_code)
         print(beneficiaries.text)
         os.system("pause")
+        return []
 
 
 def get_min_age(beneficiary_dtls):


### PR DESCRIPTION
When you have no beneficiaries, the script will error. However a rather prude `Nonetype` error occurs. Returning a empty list should solve the issue.

```sh
Fetching registered beneficiaries..
Unable to fetch beneficiaries
400
{"errorCode":"APPOIN0001","error":"No beneficiary found for provided beneficiary mobile number 3"}
sh: pause: command not found
object of type 'NoneType' has no len()
Exiting Script
sh: pause: command not found
```

An alternate would be a simple, NoneCheck, which I can do instead!