### PR TITLE
Add notification support for linux and mac OS

### DIFF
--- a/src/covid-vaccine-slot-booking.py
+++ b/src/covid-vaccine-slot-booking.py
@@ -90,6 +90,19 @@ def main():
         print(" ==== BE CAREFUL WITH THIS OPTION! AUTO-BOOKING WILL BOOK THE FIRST AVAILABLE CENTRE, DATE, AND SLOT! ==== ")
         auto_book = input("Do you want to enable auto-booking? (yes-please or no): ")
 
+        print("\n=================== Starting search with below information ===================")
+        print("Vaccine type: " + vaccine_type)
+        print("Auto book: " + str(auto_book == "yes-please"))
+        display_start_date = ""
+        if isinstance(start_date, int):
+            display_start_date = datetime.date.today() + datetime.timedelta(days=start_date-1)
+        else:
+            display_start_date = datetime.datetime.strptime(start_date, '%Y-%m-%d').date()
+        print("Slot search starting date: " + str(display_start_date))
+        print("Refresh interval: " + str(refresh_freq) + " seconds")
+        print("Minimum slots: " + str(minimum_slots))
+        print("=================== =================== =================== ===================\n")
+
         token_valid = True
         while token_valid:
             request_header = copy.deepcopy(base_request_header)

--- a/src/utils.py
+++ b/src/utils.py
@@ -35,7 +35,7 @@ except ImportError:
             message = "Attention required"
             title = "Covid booking"
             try:
-                os.system('notify-send "%s" -a "%s" -u critical -t %s' % (message, title, duration))
+                os.system('notify-send "{1} - {0}" -a "{1}" -u critical -t {2}'.format(message, title, duration))
             except:
                 os.system('echo "%s %s"' % (title, message))
             # apt-get install beep  --> install beep package on linux distros before running

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,6 +17,14 @@ except ImportError:
     if sys.platform == "darwin":
 
         def beep(freq, duration):
+            # send notification on mac os.
+            # Source: https://code-maven.com/display-notification-from-the-mac-command-line
+            message = "Attention required"
+            title = "Covid booking"
+            try:
+                os.system("osascript -e 'display notification \"%s\" with title \"%s\"'" % (message, title))
+            except:
+                os.system('echo "%s %s"' % (title, message))
             # brew install SoX --> install SOund eXchange universal sound sample translator on mac
             os.system(
                 f"play -n synth {duration / 1000} sin {freq} >/dev/null 2>&1")

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,6 +15,13 @@ except ImportError:
     import os
 
     def beep(freq, duration):
+        # send notification. Requires "libnotify". Already present in almost all distros.
+        message = "Attention required"
+        title = "Covid booking"
+        try:
+            os.system('notify-send "%s" -a "%s" -u critical -t %s' % (message, title, duration))
+        except:
+            os.system('echo "%s %s"' % (title, message))
         # apt-get install beep  --> install beep package on linux distros before running
         os.system('beep -f %s -l %s' % (freq, duration))
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,16 +14,24 @@ try:
 except ImportError:
     import os
 
-    def beep(freq, duration):
-        # send notification. Requires "libnotify". Already present in almost all distros.
-        message = "Attention required"
-        title = "Covid booking"
-        try:
-            os.system('notify-send "%s" -a "%s" -u critical -t %s' % (message, title, duration))
-        except:
-            os.system('echo "%s %s"' % (title, message))
-        # apt-get install beep  --> install beep package on linux distros before running
-        os.system('beep -f %s -l %s' % (freq, duration))
+    if sys.platform == "darwin":
+
+        def beep(freq, duration):
+            # brew install SoX --> install SOund eXchange universal sound sample translator on mac
+            os.system(
+                f"play -n synth {duration / 1000} sin {freq} >/dev/null 2>&1")
+    else:
+
+        def beep(freq, duration):
+            # send notification. Requires "libnotify". Already present in almost all distros.
+            message = "Attention required"
+            title = "Covid booking"
+            try:
+                os.system('notify-send "%s" -a "%s" -u critical -t %s' % (message, title, duration))
+            except:
+                os.system('echo "%s %s"' % (title, message))
+            # apt-get install beep  --> install beep package on linux distros before running
+            os.system('beep -f %s -l %s' % (freq, duration))
 
 else:
     def beep(freq, duration):


### PR DESCRIPTION
Notification is useful if sound card is broken for some reason.

There might be some merge conflicts, the beep part for mac OS is implemented in `main` branch but not in this branch.
The beep part of the code is copied from `main` branch.
But I assume you are using pycharm and  such conflicts can be easily resolved.

Notification for mac OS should work fine but not tested using python. The `osascript` command seems to be working when used directly from terminal.