### PR TITLE
URGENT - Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests
 tabulate
 inputimeout
 svglib==1.0.1
-reportlab
+reportlab==3.5.59
 pyinstaller
 pysimplegui


### PR DESCRIPTION
URGENT CHANGES
Solution to convert svg to png by using `svglib` or `reportlab` don't work out-of-the-box on Python3 + Windows. 
I was getting `AttributeError: 'Image' object has no attribute 'fromstring'` error and it is not handled in the code. I had to debug it manually from the generated svg file during slot booking.

Referring to this : https://stackoverflow.com/questions/65759849/convert-svg-to-png-with-python-on-windows

The solution is to install `svglib` version 1.0.1 and `reportlab` 3.5.59