### PR TITLE
Updated instructions to Install Tkinter in Python on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ MacOS:
 ```
 brew install sox
 ```
+Install Tkinter in Python
+brew install python-tk@3.9
+```
 
 Finally, run the script file as shown below:
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ MacOS:
 brew install sox
 ```
 Install Tkinter in Python
+```
 brew install python-tk@3.9
 ```
 


### PR DESCRIPTION
Tkinter not available with Python by default on MacOS. The formulae can be installed with brew. 